### PR TITLE
feat: Update average_max_value calculations to exclude zero and negative values

### DIFF
--- a/custom_components/power_max_tracker/coordinator.py
+++ b/custom_components/power_max_tracker/coordinator.py
@@ -327,18 +327,18 @@ class PowerMaxCoordinator:
 
     @property
     def average_max_value(self):
-        """Return the average of all max values."""
-        if self.max_values:
-            return sum(self.max_values) / len(self.max_values)
+        """Return the average of all max values greater than 0 (excludes zero and negative values)."""
+        positive_values = [v for v in self.max_values if v > 0]
+        if positive_values:
+            return sum(positive_values) / len(positive_values)
         return 0.0
 
     @property
     def previous_month_average_max_value(self):
-        """Return the average of previous month max values."""
-        if self.previous_month_max_values:
-            return sum(self.previous_month_max_values) / len(
-                self.previous_month_max_values
-            )
+        """Return the average of previous month max values greater than 0 (excludes zero and negative values)."""
+        positive_values = [v for v in self.previous_month_max_values if v > 0]
+        if positive_values:
+            return sum(positive_values) / len(positive_values)
         return 0.0
 
     def _watts_to_kilowatts(self, watts: float) -> float:

--- a/custom_components/power_max_tracker/coordinator.py
+++ b/custom_components/power_max_tracker/coordinator.py
@@ -325,21 +325,29 @@ class PowerMaxCoordinator:
             )
         )
 
-    @property
-    def average_max_value(self):
-        """Return the average of all max values greater than 0 (excludes zero and negative values)."""
-        positive_values = [v for v in self.max_values if v > 0]
+    def _average_positive(self, values: list[float]) -> float:
+        """Calculate the average of values greater than 0 (excludes zero and negative values).
+
+        Args:
+            values: List of float values to average
+
+        Returns:
+            Average of positive values, or 0.0 if no positive values exist
+        """
+        positive_values = [v for v in values if v > 0]
         if positive_values:
             return sum(positive_values) / len(positive_values)
         return 0.0
 
     @property
+    def average_max_value(self):
+        """Return the average of all max values greater than 0 (excludes zero and negative values)."""
+        return self._average_positive(self.max_values)
+
+    @property
     def previous_month_average_max_value(self):
         """Return the average of previous month max values greater than 0 (excludes zero and negative values)."""
-        positive_values = [v for v in self.previous_month_max_values if v > 0]
-        if positive_values:
-            return sum(positive_values) / len(positive_values)
-        return 0.0
+        return self._average_positive(self.previous_month_max_values)
 
     def _watts_to_kilowatts(self, watts: float) -> float:
         """Convert watts to kilowatts.

--- a/custom_components/power_max_tracker/tests/test_coordinator.py
+++ b/custom_components/power_max_tracker/tests/test_coordinator.py
@@ -143,7 +143,16 @@ class TestPowerMaxCoordinator:
     def test_average_max_value_with_zeros(self, coordinator):
         """Test average_max_value property with some zero values."""
         coordinator.max_values = [10.0, 0.0, 5.0]
-        assert coordinator.average_max_value == 5.0  # (10 + 0 + 5) / 3 = 5.0
+        assert (
+            coordinator.average_max_value == 7.5
+        )  # (10 + 5) / 2 = 7.5 (zeros excluded)
+
+    def test_average_max_value_with_negatives(self, coordinator):
+        """Test average_max_value property with negative values."""
+        coordinator.max_values = [10.0, -5.0, 5.0]
+        assert (
+            coordinator.average_max_value == 7.5
+        )  # (10 + 5) / 2 = 7.5 (negatives excluded)
 
     def test_previous_month_average_max_value_empty_list(self, coordinator):
         """Test previous_month_average_max_value property with empty list."""
@@ -166,8 +175,15 @@ class TestPowerMaxCoordinator:
         """Test previous_month_average_max_value property with some zero values."""
         coordinator.previous_month_max_values = [15.0, 0.0, 5.0]
         assert (
-            coordinator.previous_month_average_max_value == 6.666666666666667
-        )  # (15 + 0 + 5) / 3
+            coordinator.previous_month_average_max_value == 10.0
+        )  # (15 + 5) / 2 = 10.0 (zeros excluded)
+
+    def test_previous_month_average_max_value_with_negatives(self, coordinator):
+        """Test previous_month_average_max_value property with negative values."""
+        coordinator.previous_month_max_values = [15.0, -5.0, 5.0]
+        assert (
+            coordinator.previous_month_average_max_value == 10.0
+        )  # (15 + 5) / 2 = 10.0 (negatives excluded)
 
     def test_update_max_values_with_timestamp_new_value(self, coordinator):
         """Test updating max values with a new value."""


### PR DESCRIPTION
This pull request updates the logic for calculating average maximum values in the `PowerMaxTracker` coordinator to exclude zero and negative values, ensuring more accurate averages. Corresponding tests have been updated and expanded to verify the new behavior, including cases with negative values.

Calculation logic improvements:

* The `average_max_value` and `previous_month_average_max_value` properties in `coordinator.py` now compute averages using only positive values, excluding zeros and negatives from the calculation.

Test enhancements:

* Updated existing tests in `test_coordinator.py` to expect averages that exclude zero values, reflecting the new calculation logic. [[1]](diffhunk://#diff-c7854ab22c7d6a28741eecc36394790b9ad7cb886c0ecc646585f988b731ec3bL146-R155) [[2]](diffhunk://#diff-c7854ab22c7d6a28741eecc36394790b9ad7cb886c0ecc646585f988b731ec3bL169-R186)
* Added new tests to verify that negative values are also excluded from the average calculations for both current and previous month maximum values. [[1]](diffhunk://#diff-c7854ab22c7d6a28741eecc36394790b9ad7cb886c0ecc646585f988b731ec3bL146-R155) [[2]](diffhunk://#diff-c7854ab22c7d6a28741eecc36394790b9ad7cb886c0ecc646585f988b731ec3bL169-R186)

Fixes #41 